### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/user.js
+++ b/lib/user.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let htpasswd = require('htpasswd-auth');
-let uuid = require('node-uuid');
+let uuid = require('uuid');
 let storage = require('./storage');
 let config = require('./config');
 let path = require('path');

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "author": "Bhanu P Chaudhary (@bhanuc)",
   "license": "ISC",
   "dependencies": {
+    "alphonso-fs": "https://github.com/bhanuc/alphonso-fs.git",
+    "alphonso-s3": "https://github.com/bhanuc/alphonso-s3.git",
     "bluebird": "3.3.4",
     "co": "^4.5.4",
     "co-body": "4.0.0",
     "got": "6.1.1",
     "htpasswd-auth": "https://github.com/bhanuc/htpasswd-auth.git",
-    "alphonso-fs": "https://github.com/bhanuc/alphonso-fs.git",
-    "alphonso-s3": "https://github.com/bhanuc/alphonso-s3.git",
     "ioredis": "^1.5.0",
     "knox": "^0.9.2",
     "koa": "1.1.2",
@@ -28,8 +28,8 @@
     "metric-log": "1.0.1",
     "mkdirp": "^0.5.1",
     "mz": "^2.3.1",
-    "node-uuid": "^1.4.3",
-    "rollbar": "0.5.13"
+    "rollbar": "0.5.13",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.